### PR TITLE
Automatically resolve static IP conflicts

### DIFF
--- a/nomad/util.py
+++ b/nomad/util.py
@@ -48,3 +48,6 @@ def boolval(val):
 
 def is_provisioned(container):
     return container.config.get('user.nomad.provisioned') == 'true'
+
+def has_static_ip(container):
+    return container.config.get('user.nomad.static_ip') == 'true'


### PR DESCRIPTION
When a project is initially started and needs a static IP, no problem.
But if we stop the project, start *another* project that akso needs a
static IP, and then try to start our first project again, we'll get an
IP conflict.

This commit solves this problem by:

1. Marking containers needing a static IP in the config.
2. Re-assigning a new static IP before starting any such marked
   container.