### PR TITLE
Allow the same project to live in separate containers

### DIFF
--- a/nomad/config.py
+++ b/nomad/config.py
@@ -2,6 +2,7 @@ import yaml
 
 class Config(dict):
     def __init__(self, path):
+        self.homedir = path.resolve().parent
         with path.open('rb') as fp:
             d = yaml.load(fp)
         self.update(d)


### PR DESCRIPTION
Having the container name exactly as the project name in the
`.nomad.yml` file is kind of limiting because you can't have the project
live in multiple containers (to try an experimental feature, for
example).

With this commit, we set a `user.nomad.homedir` config at container
creation to the absolute path of our project (config file). When we try
to run `nomad up` from a directory that isn't referenced by any
container, we create a new one and mangle its name if there's a naming
conflict.