### PR TITLE
Add pull mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ provisioning:
 *something* out of `nomad` commands made in the same folder.
 
 You can also choose to define a container that will be created by pulling directly one of the image
-hosted on https://images.linuxcontainers.org/: this is the "pull" mode:
+hosted on https://images.linuxcontainers.org/. This is the "pull" mode:
 
 ```
 name: myproject
-image: ubuntu/xenial/amd64
+image: ubuntu/xenial
 mode: pull
 hostnames:
   - myproject.local
@@ -55,11 +55,11 @@ provisioning:
     playbook: deploy/site.yml
 ```
 
-It should be noted that the ``image`` value should contain a name of a container alias that includes
-the targetted architecture (eg. ``debian/jessie/amd64`` or ``ubuntu/xenial/armhf``). The image will
-be pulled from the https://images.linuxcontainers.org/ image server by default (so you can get a
-list of supported aliases by using the ``lxc image alias list images:`` command). You can also
-choose to use another server by manually setting the ``server`` value.
+It should be noted that the ``image`` value can also contain a name of a container alias that
+includes the targetted architecture (eg. ``debian/jessie/amd64`` or ``ubuntu/xenial/armhf``). The
+image will be pulled from the https://images.linuxcontainers.org/ image server by default (so you
+can get a list of supported aliases by using the ``lxc image alias list images:`` command). You can
+also choose to use another server by manually setting the ``server`` value.
 
 ## Privileged containers
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ Barely functional, work in progress.
 ## Requirements
 
 * A functional LXD. You should be able to run `lxc launch` and have a container with an IPv4
-  address running.
+  address running
 * Proper permissions to run the `lxc` command. That usually means adding your user to the `lxd`
-  group.
-* Local LXD images. *LXD-Nomad* doesn't manage image copying. When you refer to `debian/jessie`, you need
-  to have already coplied the image locally and properly aliased it.
-* `getfacl/setfacl` if you use shared folders.
+  group
+* `getfacl/setfacl` if you use shared folders
 * pylxd
 * ansible
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,29 @@ provisioning:
 ... and that you have a pre-configured `jessie` container that works, you should be able to get
 *something* out of `nomad` commands made in the same folder.
 
+You can also choose to define a container that will be created by pulling directly one of the image
+hosted on https://images.linuxcontainers.org/: this is the "pull" mode:
+
+```
+name: myproject
+image: ubuntu/xenial/amd64
+mode: pull
+hostnames:
+  - myproject.local
+shares:
+  - source: .
+    dest: /myshare
+provisioning:
+  - type: ansible
+    playbook: deploy/site.yml
+```
+
+It should be noted that the ``image`` value should contain a name of a container alias that includes
+the targetted architecture (eg. ``debian/jessie/amd64`` or ``ubuntu/xenial/armhf``). The image will
+be pulled from the https://images.linuxcontainers.org/ image server by default (so you can get a
+list of supported aliases by using the ``lxc image alias list images:`` command). You can also
+choose to use another server by manually setting the ``server`` value.
+
 ## Privileged containers
 
 There seems to be some problems with containers running systemd-based systems. Their init system

--- a/nomad/container.py
+++ b/nomad/container.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 class Container(object):
     """ Represents a specific container that is managed by LXD-Nomad. """
 
+    # The default image server that will be used to pull images in "pull" mode.
+    _default_image_server = 'https://images.linuxcontainers.org'
+
     def __init__(self, project_name, homedir, client, name=None, **options):
         self.project_name = project_name
         self.homedir = homedir
@@ -176,9 +179,25 @@ class Container(object):
             'Creating new container "{name}" '
             'from image {image}'.format(name=name, image=self.options['image']))
         privileged = self.options.get('privileged', False)
+        mode = self.options.get('mode', 'local')
         container_config = {
             'name': name,
-            'source': {'type': 'image', 'alias': self.options['image']},
+            'source': {
+                'alias': self.options['image'],
+                # The 'mode' defines how the container will be retrieved. In "local" mode the image
+                # will be determined using a local alias. In "pull" mode the image will be fetched
+                # from a remote server using a remote alias.
+                'mode': mode,
+                # The 'protocol' to use. LXD supports two protocol: 'lxd' (default - RESTful API
+                # that is used between the clients and a LXD daemon) and 'simplestreams'.
+                'protocol': self.options.get('protocol', 'lxd'),
+                # The 'server' that should be used to fetch the images. We use the default
+                # linuxcontainers server for LXC and LXD when no value is provided (and if we are
+                # not in "local" mode).
+                'server': (self.options.get('server', self._default_image_server) if mode == 'pull'
+                           else ''),
+                'type': 'image',
+            },
             'config': {
                 'security.privileged': 'true' if privileged else 'false',
                 'user.nomad.homedir': self.homedir,

--- a/nomad/container.py
+++ b/nomad/container.py
@@ -188,9 +188,12 @@ class Container(object):
                 # will be determined using a local alias. In "pull" mode the image will be fetched
                 # from a remote server using a remote alias.
                 'mode': mode,
-                # The 'protocol' to use. LXD supports two protocol: 'lxd' (default - RESTful API
-                # that is used between the clients and a LXD daemon) and 'simplestreams'.
-                'protocol': self.options.get('protocol', 'lxd'),
+                # The 'protocol' to use. LXD supports two protocol: 'lxd' (RESTful API that is used
+                # between the clients and a LXD daemon) and 'simplestreams' (an image server
+                # description format, using JSON to describe a list of images and allowing to get
+                # image information and import images). We use "simplestreams" by default (as the
+                # lxc command do).
+                'protocol': self.options.get('protocol', 'simplestreams'),
                 # The 'server' that should be used to fetch the images. We use the default
                 # linuxcontainers server for LXC and LXD when no value is provided (and if we are
                 # not in "local" mode).


### PR DESCRIPTION
Add support for pull mode: this allows to create containers without having to copy them. The image are fetched from the linuxcontainers image server by default (but this can be configured of course).

One thing: for now the "local" mode remains the default mode for LXD-Nomad, but I think that the "pull" mode should be the default mode because it allows a workflow that is much more simple than the "local" mode (you don't have to initially copy the image and its aliases before using the nomad command).